### PR TITLE
Fixing both destructor compiler errors/warnings

### DIFF
--- a/scope_guard.hpp
+++ b/scope_guard.hpp
@@ -127,6 +127,14 @@ namespace sg
 
     };
 
+    ////////////////////////////////////////////////////////////////////////////////
+    template<typename Callback>
+    scope_guard<Callback>::~scope_guard() noexcept
+    {
+      if(m_active)
+        m_callback();
+    }
+
   } // namespace detail
 
 
@@ -146,14 +154,6 @@ noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
     https://is.gd/Tsmh8G) */
   , m_active{true}
 {}
-
-////////////////////////////////////////////////////////////////////////////////
-template<typename Callback>
-sg::detail::scope_guard<Callback>::~scope_guard<Callback>() noexcept
-{
-  if(m_active)
-    m_callback();
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 template<typename Callback>


### PR DESCRIPTION
There are two errors/warnings which seem to conflict:
* GCC 11 with C++20 enabled gives the error:
  ```
  scope_guard/scope_guard.hpp:152:36: error: template-id not allowed for destructor
    152 | sg::detail::scope_guard<Callback>::~scope_guard<Callback>() noexcept
          |                                    ^
  ```
* Clang 12/13/14 triggers the warning `-Wdtor-name`:
  ```
  warning: ISO C++ requires the name after ‘::~’ to be found in the same scope as the name before ‘::~’
  ```
  Note: this was (incorrectly) fixed with pull request #10 right before the last release

After some testing I believe the following modification fixes both problems:
* Remove the template name from the destructor name
* Move the destructor definition into the same namespace as the template argument definition argument